### PR TITLE
Make wallets use the ID thats physically in the first slot in the wallet

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -67,7 +67,7 @@
 		var/card_tally = SSid_access.tally_access(id_card, ACCESS_FLAG_COMMAND)
 		if(card_tally > winning_tally)
 			winning_tally = card_tally
-			front_id = id_card
+			front_id = id_card //searches for the id that will show on secHUD
 		LAZYINITLIST(combined_access)
 		combined_access |= id_card.access
 
@@ -79,7 +79,8 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/wearing_human = loc
 		if(wearing_human.wear_id == src)
-			wearing_human.sec_hud_set_ID()
+			wearing_human.sec_hud_set_ID() //sets the sechud icon
+			front_id = (locate(/obj/item/card/id) in contents) //picks first id in the wallet as the appearance of it
 
 	update_label()
 	update_appearance(UPDATE_ICON)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
wallets now use the first id in the slot physically, sechuds are untouched
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
 the way how id rework made it work was horrendous imo
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Wallets now use front first id instead of highest ranking one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
