### PR TITLE
Makes Department Airlock Wires Configurable

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -38,6 +38,8 @@
 
 /datum/config_entry/flag/sec_start_brig //makes sec start in brig instead of dept sec posts
 
+/datum/config_entry/flag/wires_can_use_dictionary_keys // gives airlocks different wire patterns for each part of the station
+
 /datum/config_entry/flag/force_random_names
 
 /datum/config_entry/flag/humans_need_surnames

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -48,8 +48,13 @@
 
 	src.holder = holder
 
-	// If there is a dictionary key set, we'll want to use that. Otherwise, use the holder type.
-	var/key = dictionary_key ? dictionary_key : holder_type
+	var/key = null
+	// If this config is set, wires may be set by their dictionary key. (Doors use this for department based wiring.)
+	if(CONFIG_GET(flag/wires_can_use_dictionary_keys))
+		// If there is a dictionary key set, we'll want to use that. Otherwise, use the holder type.
+		key = dictionary_key ? dictionary_key : holder_type
+	else
+		key = holder_type
 
 	RegisterSignal(holder, COMSIG_PARENT_QDELETING, .proc/on_holder_qdel)
 	if(randomize)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -302,6 +302,8 @@ EVERYONE_HAS_MAINT_ACCESS
 ## Comment this out this to make security officers spawn in departmental security posts
 SEC_START_BRIG
 
+## Comment this out to make airlocks use a common wire dictionary instead of a different dictionary for each part of the station.
+#WIRES_CAN_USE_DICTIONARY_KEYS
 
 ## GHOST INTERACTION ###
 ## Uncomment to let ghosts spin chairs. You may be wondering why this is a config option. Don't ask.


### PR DESCRIPTION
Right now airlock wires are set to be the same within a given department but different between them. Understanding this it's a lot less annoying than what you might assume (it being random for every airlock) but I've poached [this PR](https://github.com/tgstation/tgstation/pull/54826/files) from user [jaw-sh](https://github.com/jaw-sh) and hope it works as advertised. It will default to universal wires as I've set it up.

config.txt

## Comment this out to make airlocks use a common wire dictionary instead of a different dictionary for each part of the station.
WIRES_CAN_USE_DICTIONARY_KEYS