### PR TITLE
R&D consoles in R&D

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -24765,11 +24765,11 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "deh" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/computer/rdconsole{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/lab)
@@ -25353,8 +25353,8 @@
 /turf/open/floor/iron,
 /area/science/lab)
 "dgP" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "dgQ" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -11636,7 +11636,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bpf" = (
-/obj/machinery/modular_computer/console/preset/civilian{
+/obj/machinery/computer/rdconsole{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -47644,6 +47644,9 @@
 	dir = 4
 	},
 /obj/machinery/bounty_board/directional/west,
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "skK" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -11445,6 +11445,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aMi" = (
@@ -15516,7 +15517,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/science/mixing)
 "aXn" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -15524,12 +15524,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high,
+/obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "aXo" = (
@@ -17977,7 +17972,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/modular_computer/console/preset/civilian{
+/obj/machinery/computer/rdconsole{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -34148,6 +34143,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "cmh" = (
@@ -47898,18 +47894,6 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "fOh" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
 /obj/machinery/light_switch/directional/west{
 	pixel_y = -4
 	},
@@ -47919,7 +47903,27 @@
 	pixel_y = 6;
 	req_access_txt = "7"
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/science/lab)
 "fOi" = (
 /obj/effect/turf_decal/tile/neutral,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -62121,6 +62121,9 @@
 /area/science/mixing)
 "spA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/science/lab)
 "spD" = (
@@ -70446,10 +70449,10 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "uZe" = (
-/obj/machinery/modular_computer/console/preset/civilian,
 /obj/effect/turf_decal/siding{
 	dir = 1
 	},
+/obj/machinery/computer/rdconsole,
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "uZj" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -38477,6 +38477,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "kHb" = (
@@ -60850,7 +60851,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "tyc" = (
-/obj/machinery/modular_computer/console/preset/civilian,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -60860,6 +60860,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/computer/rdconsole,
 /turf/open/floor/iron,
 /area/science/lab)
 "tyF" = (
@@ -65070,6 +65071,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"vfN" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/lab)
 "vfS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -181191,7 +181204,7 @@ iiA
 bLs
 jrL
 oky
-bWJ
+vfN
 xEz
 xXZ
 seb


### PR DESCRIPTION
Reverts a change made where only the RD was authorized to unlock research. R&D consoles now spawn in R&D.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-adds R&D consoles to R&D along with very minor changes to accomodate for civillian consoles. (few things moved a little)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows scientists to do science, also essential for those times when there is no RD.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: R&D computers have been added to R&D.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
