### PR TITLE
Chem Assembly: "variables" & fixed labels.

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemAssembler.js
+++ b/tgui/packages/tgui/interfaces/ChemAssembler.js
@@ -61,7 +61,7 @@ export const ChemAssembler = (props, context) => {
               </NoticeBox>
             )}
             <Section>
-              <TextArea fluid width="100%" height={data.error ? "298px" : "327px"} value={program_text}
+              <TextArea fontFamily="monospace" fluid width="100%" height={data.error ? "298px" : "327px"} value={program_text}
                 onChange={(e, value) => act("update_program", {
                   text: value,
                 })} />


### PR DESCRIPTION
Fixes labels when defined in a specific way causing runtimes and added .variables (which are more like `#define`s for arguments)
Also 
![image](https://user-images.githubusercontent.com/34602646/124911860-ebbdd400-dff5-11eb-8867-3b40cf98a117.png)
the UI now uses a monospace font