### PR TITLE
Watch these cool prs

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -58,7 +58,9 @@
 	if(!msg)
 		return
 
-	user.log_message(msg, LOG_EMOTE)
+	if(ishuman(user) || user.ckey)
+		user.log_message(msg, LOG_EMOTE)
+		
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
 	var/tmp_sound = get_sound(user)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -942,7 +942,7 @@ DEFINE_BITFIELD(turret_flags, list(
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 
 /obj/machinery/turretid/AltClick(mob/user)
-	if(stat & BROKEN)
+	if(machine_stat & BROKEN)
 		return
 	togglelock(user)
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -931,7 +931,7 @@ DEFINE_BITFIELD(turret_flags, list(
 
 	togglelock(user)		// trying to unlock the interface
 
-			/obj/machinery/turretid/proc/togglelock(mob/user)
+/obj/machinery/turretid/proc/togglelock(mob/user)
 	if (allowed(user))
 		if(obj_flags & EMAGGED)
 			to_chat(user, "<span class='notice'>The turret control is unresponsive.</span>")

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -929,16 +929,22 @@ DEFINE_BITFIELD(turret_flags, list(
 	if (issilicon(user))
 		return attack_hand(user)
 
-	if ( get_dist(src, user) == 0 ) // trying to unlock the interface
-		if (allowed(usr))
-			if(obj_flags & EMAGGED)
-				to_chat(user, "<span class='warning'>The turret control is unresponsive!</span>")
-				return
+	togglelock(user)		// trying to unlock the interface
 
-			locked = !locked
-			to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the panel.</span>")
-		else
-			to_chat(user, "<span class='alert'>Access denied.</span>")
+			/obj/machinery/turretid/proc/togglelock(mob/user)
+	if (allowed(user))
+		if(obj_flags & EMAGGED)
+			to_chat(user, "<span class='notice'>The turret control is unresponsive.</span>")
+			return
+		locked = !locked
+		to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the panel.</span>")
+	else
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+
+/obj/machinery/turretid/AltClick(mob/user)
+	if(stat & BROKEN)
+		return
+	togglelock(user)
 
 /obj/machinery/turretid/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -166,7 +166,7 @@ GENE SCANNER
 		mob_status = "<span class='alert'><b>Deceased</b></span>"
 		oxy_loss = max(rand(1, 40), oxy_loss, (300 - (tox_loss + fire_loss + brute_loss))) // Random oxygen loss
 
-	if(ishuman(M) || istype(M,/mob/living/carbon/monkey)) // Monkey organs can also be shown now
+	if(iscarbon(M))
 		var/mob/living/carbon/human/H = M
 		if(H.undergoing_cardiac_arrest() && H.stat != DEAD)
 			render_list += "<span class='alert'>Subject suffering from heart attack: Apply defibrillation or other electric shock immediately!</span>\n"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -402,17 +402,18 @@ GENE SCANNER
 				var/mob/living/carbon/human/H = C
 				if(H.is_bleeding())
 					var/bleedtext = ""
-					if(H.bleed_rate <= 5)
+					var/bleed_rate = H.get_total_bleed_rate()
+					if(bleed_rate <= 5)
 						bleedtext = "Negligible"
-					else if(H.bleed_rate <= 10)
+					else if(bleed_rate <= 10)
 						bleedtext = "Minor"
-					else if(H.bleed_rate <= 15)
+					else if(bleed_rate <= 15)
 						bleedtext = "Moderate"
-					else if(H.bleed_rate <= 20)
+					else if(bleed_rate <= 20)
 						bleedtext = "Serious"
-					else if(H.bleed_rate <= 30)
+					else if(bleed_rate <= 30)
 						bleedtext = "Critical!"
-					else if(H.bleed_rate > 30)
+					else if(bleed_rate > 30)
 						bleedtext = "Extreme!"
 					var/bandagetext = ""
 					if(H.bleedsuppress)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -418,7 +418,7 @@ GENE SCANNER
 					var/bandagetext = ""
 					if(H.bleedsuppress)
 						bandagetext = "Bandaged"
-					render_list += "<span class='alert ml-1'><b>Subject is bleeding! [bleedtext ? "([bleedtext])" : ""][bandagetext ? "(Bandaged)" : ""]</b></span>\n"
+					render_list += "<span class='alert ml-1'><b>Subject is bleeding! [bleedtext ? "([bleedtext])" : ""]</b></span>\n"
 			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL)*100)
 			var/blood_type = C.dna.blood_type
 			if(blood_id != /datum/reagent/blood) // special blood substance

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -166,7 +166,7 @@ GENE SCANNER
 		mob_status = "<span class='alert'><b>Deceased</b></span>"
 		oxy_loss = max(rand(1, 40), oxy_loss, (300 - (tox_loss + fire_loss + brute_loss))) // Random oxygen loss
 
-	if(ishuman(M))
+	if(ishuman(M) || istype(M,/mob/living/carbon/monkey)) // Monkey organs can also be shown now
 		var/mob/living/carbon/human/H = M
 		if(H.undergoing_cardiac_arrest() && H.stat != DEAD)
 			render_list += "<span class='alert'>Subject suffering from heart attack: Apply defibrillation or other electric shock immediately!</span>\n"
@@ -401,7 +401,23 @@ GENE SCANNER
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C
 				if(H.is_bleeding())
-					render_list += "<span class='alert ml-1'><b>Subject is bleeding!</b></span>\n"
+					var/bleedtext = ""
+					if(H.bleed_rate <= 5)
+						bleedtext = "Negligible"
+					else if(H.bleed_rate <= 10)
+						bleedtext = "Minor"
+					else if(H.bleed_rate <= 15)
+						bleedtext = "Moderate"
+					else if(H.bleed_rate <= 20)
+						bleedtext = "Serious"
+					else if(H.bleed_rate <= 30)
+						bleedtext = "Critical!"
+					else if(H.bleed_rate > 30)
+						bleedtext = "Extreme!"
+					var/bandagetext = ""
+					if(H.bleedsuppress)
+						bandagetext = "Bandaged"
+					render_list += "<span class='alert ml-1'><b>Subject is bleeding! [bleedtext ? "([bleedtext])" : ""][bandagetext ? "(Bandaged)" : ""]</b></span>\n"
 			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL)*100)
 			var/blood_type = C.dna.blood_type
 			if(blood_id != /datum/reagent/blood) // special blood substance

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -415,9 +415,6 @@ GENE SCANNER
 						bleedtext = "Critical!"
 					else if(bleed_rate > 30)
 						bleedtext = "Extreme!"
-					var/bandagetext = ""
-					if(H.bleedsuppress)
-						bandagetext = "Bandaged"
 					render_list += "<span class='alert ml-1'><b>Subject is bleeding! [bleedtext ? "([bleedtext])" : ""]</b></span>\n"
 			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL)*100)
 			var/blood_type = C.dna.blood_type


### PR DESCRIPTION
## About The Pull Request

1) Makes emotes only log if performed by players, so no more 5 terrabyte logs because "Monkey (281) gasped!x20"
2) Allows turrets to be accessed 1 tile away, and can now be alt-clicked to unlock/lock.
3) Health Analyzers now show the severity of a bleed.

## Why It's Good For The Game

1) Smaller logs, easier to read and comprehend, meaning swifter punishments and faster and more precise conclusions
2) Ease of use
3) More depth to health alanyzers

## Changelog
:cl:
add: Health Analyzers now show severity of a bleed.
qol: Turrets can now be accessed 1 tile away, and can be locked/unlocked with alt-click
admin: Emotes are only logged if performed by players.
/:cl:
